### PR TITLE
H10 Feature: Adjust lexer to support indentation mode

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -5,12 +5,26 @@ use std::collections::HashMap;
 use crate::rules::Rules;
 use crate::compiler::lexer::Lexer;
 
+#[derive(Clone, PartialEq)]
+pub enum SeparatorMode {
+    Manual,
+    Automatic
+}
+
+#[derive(Clone, PartialEq)]
+pub enum ScopingMode {
+    Block,
+    Indent
+}
+
 pub struct Compiler<AST> {
     pub name: String,
     pub rules: Rules,
     pub code: String,
     pub path: String,
-    pub code_tree: HashMap<String, AST>
+    pub code_tree: HashMap<String, AST>,
+    pub separator_mode: SeparatorMode,
+    pub scoping_mode: ScopingMode
 }
 
 impl<AST> Compiler<AST> {
@@ -20,7 +34,9 @@ impl<AST> Compiler<AST> {
             rules,
             code: format!(""),
             path: format!("[code]"),
-            code_tree: HashMap::new()
+            code_tree: HashMap::new(),
+            separator_mode: SeparatorMode::Automatic,
+            scoping_mode: ScopingMode::Block
         }
     }
 

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -5,15 +5,19 @@ use std::collections::HashMap;
 use crate::rules::Rules;
 use crate::compiler::lexer::Lexer;
 
+// TODO: Create Block interface when building scoper
+type Block = ();
+
 #[derive(Clone, PartialEq)]
 pub enum SeparatorMode {
     Manual,
+    SemiAutomatic,
     Automatic
 }
 
 #[derive(Clone, PartialEq)]
 pub enum ScopingMode {
-    Block,
+    Block(Vec<Block>),
     Indent
 }
 
@@ -36,7 +40,7 @@ impl<AST> Compiler<AST> {
             path: format!("[code]"),
             code_tree: HashMap::new(),
             separator_mode: SeparatorMode::Automatic,
-            scoping_mode: ScopingMode::Block
+            scoping_mode: ScopingMode::Block(vec![])
         }
     }
 

--- a/src/compiler/lexer/lexer.rs
+++ b/src/compiler/lexer/lexer.rs
@@ -2,6 +2,22 @@ use crate::compiler::{ Compiler, Token, SeparatorMode, ScopingMode };
 use super::region_handler::{ RegionHandler, Reaction };
 use super::reader::Reader;
 
+macro_rules! action {
+    ("add symbol", $self:expr, $word:expr, $letter:expr) => {{
+        $word = $self.add_word($word);
+        $word.push($letter);
+        $word = $self.add_word_inclusively($word);
+    }};
+    ("begin region", $self:expr, $word:expr, $letter:expr) => {{
+        $word = $self.add_word($word);
+        $word.push($letter);
+    }};
+    ("end region", $self:expr, $word:expr, $letter:expr) => {{
+        $word.push($letter);
+        $word = $self.add_word_inclusively($word);
+    }};
+}
+
 // This is just an estimation of token amount
 // inside of a typical 200-lined file.
 const AVG_TOKEN_AMOUNT: usize = 1024;
@@ -29,7 +45,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    // Add word that has been completed in previous iteration to the lexem
+    /// Add word that has been completed in previous iteration to the lexem
     fn add_word(&mut self, word: String) -> String {
         if word.len() > 0 {
             let (row, col) = self.reader.get_word_position(&word);
@@ -43,7 +59,7 @@ impl<'a> Lexer<'a> {
         else { word }
     }
 
-    // Add word that has been completed in current iteration to the lexem
+    /// Add word that has been completed in current iteration to the lexem
     fn add_word_inclusively(&mut self, word: String) -> String {
         if word.len() > 0 {
             let (row, col) = self.reader.get_word_position(&word);
@@ -57,15 +73,40 @@ impl<'a> Lexer<'a> {
         else { word }
     }
 
-    fn is_region(&self, reaction: Reaction) -> bool {
+    /// Checks whether this is a nontokenizable region
+    fn is_non_token_region(&self, reaction: Reaction) -> bool {
         if let Some(region) = self.region.get_region() {
             !region.tokenize && reaction == Reaction::Pass
         }
         else { false }
     }
 
+    /// Pattern code for adding a symbol
+    /// **[*]**
+    fn pattern_add_symbol(&mut self, mut word: String, letter: char) -> String {
+        word = self.add_word(word);
+        word.push(letter);
+        self.add_word_inclusively(word)
+    }
+
+    /// Pattern code for beginning a new region
+    /// **[**
+    fn pattern_begin_region(&mut self, mut word: String, letter: char) -> String {
+        word = self.add_word(word);
+        word.push(letter);
+        word
+    }
+
+    /// Pattern code for ending current region
+    /// **]**
+    fn pattern_end_region(&mut self, mut word: String, letter: char) -> String {
+        word.push(letter);
+        self.add_word_inclusively(word)
+    }
+
     pub fn run(&mut self) {
         let mut word = String::new();
+        let mut is_indenting = false;
         while let Some(letter) = self.reader.next() {
             // Reaction stores the reaction of the region handler
             // Have we just opened or closed some region?
@@ -73,31 +114,77 @@ impl<'a> Lexer<'a> {
             match reaction {
                 // If the region has been opened
                 // Finish the part that we have been parsing
-                Reaction::Open => {
-                    word = self.add_word(word);
-                    word.push(letter);
+                Reaction::Begin => {
+                    // This is supposed to prevent overshadowing new line
+                    // character if region rule opens with newline
+                    if letter == '\n' {
+                        word = self.pattern_add_symbol(word, letter);
+                    }
+                    word = self.pattern_begin_region(word, letter);
                 },
                 // If the region has been closed
                 // Add the closing region and finish the word
-                Reaction::Close => {
-                    word.push(letter);
-                    word = self.add_word_inclusively(word);
+                Reaction::End => {
+                    word = self.pattern_end_region(word, letter);
+                    // This is supposed to prevent overshadowing new line
+                    // character if region rule closes with newline
+                    if letter == '\n' {
+                        word = self.pattern_add_symbol(word, letter);
+                    }
                 }
                 Reaction::Pass => {
                     // Handle region scope
-                    if self.is_region(reaction) {
+                    if self.is_non_token_region(reaction) {
                         word.push(letter);
                     }
                     else {
+
+                        /******************/
+                        /* Mode modifiers */
+                        /******************/
+
+                        // Create indent regions: '\n   '
+                        if let ScopingMode::Indent = self.scoping_mode {
+                            // If we are still in the indent region - proceed
+                            if is_indenting && vec![' ', '\t'].contains(&letter) {
+                                word.push(letter);
+                            }
+                            // If it's the new line - start indent region
+                            if letter == '\n' {
+                                is_indenting = true;
+                                word = self.pattern_begin_region(word, letter);
+                            }
+                            // Check if the current letter
+                            // concludes current indent region
+                            if is_indenting {
+                                if let Some(next_char) = self.reader.peek() {
+                                    if !vec![' ', '\t'].contains(&next_char) {
+                                        word = self.add_word_inclusively(word);
+                                        is_indenting = false;
+                                    }
+                                }
+                                continue
+                            }
+                        }
+                        // Skip newline character if we want to manually insert semicolons
+                        if let SeparatorMode::Manual = self.separator_mode {
+                            if letter == '\n' {
+                                word = self.add_word(word);
+                                continue
+                            }
+                        }
+
+                        /*****************/
+                        /* Regular Lexer */
+                        /*****************/
+
                         // Skip whitespace
                         if vec![' ', '\t'].contains(&letter) {
                             word = self.add_word(word);
                         }
                         // Handle special symbols
                         else if self.symbols.contains(&letter) {
-                            word = self.add_word(word);
-                            word.push(letter);
-                            word = self.add_word_inclusively(word);
+                            word = self.pattern_add_symbol(word, letter);
                         }
                         // Handle word
                         else {

--- a/src/compiler/lexer/lexer.rs
+++ b/src/compiler/lexer/lexer.rs
@@ -1,4 +1,4 @@
-use crate::compiler::{ Compiler, Token };
+use crate::compiler::{ Compiler, Token, SeparatorMode, ScopingMode };
 use super::region_handler::{ RegionHandler, Reaction };
 use super::reader::Reader;
 
@@ -11,7 +11,9 @@ pub struct Lexer<'a> {
     region: RegionHandler,
     reader: Reader<'a>,
     lexem: Vec<Token<'a>>,
-    path: &'a String
+    path: &'a String,
+    separator_mode: SeparatorMode,
+    scoping_mode: ScopingMode
 }
 
 impl<'a> Lexer<'a> {
@@ -21,7 +23,9 @@ impl<'a> Lexer<'a> {
             region: RegionHandler::new(&cc.rules),
             reader: Reader::new(&cc.code),
             lexem: Vec::with_capacity(AVG_TOKEN_AMOUNT),
-            path: &cc.path
+            path: &cc.path,
+            separator_mode: cc.separator_mode.clone(),
+            scoping_mode: cc.scoping_mode.clone()
         }
     }
 
@@ -112,7 +116,7 @@ impl<'a> Lexer<'a> {
 mod test {
     use crate::rules::{ Region, Rules };
     use crate::reg;
-    use super::Compiler;
+    use crate::compiler::{ Compiler };
 
     #[test]
     fn test_lexer_base() {

--- a/src/compiler/lexer/reader.rs
+++ b/src/compiler/lexer/reader.rs
@@ -38,23 +38,23 @@ impl<'a> Reader<'a> {
         }
     }
 
-    // Return current index of the string
+    /// Return current index of the string
     pub fn get_index(&self) -> usize {
         self.index
     }
 
-    // Return current position in code
+    /// Return current position in code
     pub fn get_position(&self) -> (usize, usize) {
         (self.row, self.col)
     }
 
-    // Gets position of token that has been read
+    /// Gets position of token that has been read
     pub fn get_word_position(&self, word: &String) -> (usize, usize) {
         (self.row, self.col - word.len())
     }
 
-    // Get last n characters that were processed in correct order
-    // This function includes currently processed character
+    /// Get last n characters that were processed in correct order
+    /// This function includes currently processed character
     pub fn get_history(&self, n: usize) -> Option<&str> {
         let offset = self.index + 1;
         // Handle arithmetic overflow
@@ -63,7 +63,7 @@ impl<'a> Reader<'a> {
         Some(&self.code[begin..end])
     }
 
-    // Similar to `get_history` but returns a mutable String that can be owned
+    /// Similar to `get_history` but returns a mutable String that can be owned
     pub fn get_history_string(&self, n: usize) -> Option<String> {
         match self.get_history(n) {
             Some(value) => Some(String::from(value)),
@@ -71,7 +71,7 @@ impl<'a> Reader<'a> {
         }
     }
 
-    // Show next character that is going to be consumed
+    /// Show next character that is going to be consumed
     pub fn peek(&self) -> Option<char> {
         // Amount required to peek one item in the future
         let one_forward = 2;
@@ -81,8 +81,8 @@ impl<'a> Reader<'a> {
         }
     }
 
-    // Get next n characters that will be processed in correct order
-    // This function includes currently processed character
+    /// Get next n characters that will be processed in correct order
+    /// This function includes currently processed character
     pub fn get_future(&self, n: usize) -> Option<&str> {
         let begin = self.index;
         // Handle arithmetic overflow
@@ -90,7 +90,7 @@ impl<'a> Reader<'a> {
         Some(&self.code[begin..end])
     }
 
-    // Similar to `get_future` but returns a mutable String that can be owned
+    /// Similar to `get_future` but returns a mutable String that can be owned
     pub fn get_future_string(&self, n: usize) -> Option<String> {
         match self.get_future(n) {
             Some(value) => Some(String::from(value)),

--- a/src/compiler/lexer/region_handler.rs
+++ b/src/compiler/lexer/region_handler.rs
@@ -4,8 +4,8 @@ use super::reader::Reader;
 
 #[derive(PartialEq)]
 pub enum Reaction {
-    Open,
-    Close,
+    Begin,
+    End,
     Pass
 }
 
@@ -58,7 +58,6 @@ impl RegionHandler {
                             match self.region_map.get(reference_name) {
                                 // If success, then we want to do the replace
                                 Some(target_region) => {
-                                    println!("LENGTH ASSIGNED: {}", target_region.interp.len());
                                     begin_region.interp = target_region.interp.clone();
                                 },
                                 // If fail then it means that we have invalid reference name
@@ -68,7 +67,7 @@ impl RegionHandler {
                             }
                         }
                         self.region_stack.push(begin_region);
-                        return Reaction::Open;
+                        return Reaction::Begin;
                     }
                 }
             }
@@ -76,7 +75,7 @@ impl RegionHandler {
             if let Some(end_region) = self.match_region_by_end(reader) {
                 if end_region.name == region.name {
                     self.region_stack.pop();
-                    return Reaction::Close;
+                    return Reaction::End;
                 }
             }
         }
@@ -199,7 +198,7 @@ mod test {
         // Simulate matching regions
         while let Some(_) = reader.next() {
             let region_mutated = rh.handle_region(&reader);
-            if let Reaction::Open | Reaction::Close = region_mutated {
+            if let Reaction::Begin | Reaction::End = region_mutated {
                 result.push(reader.get_index());
             }
         }

--- a/src/compiler/lexer/region_handler.rs
+++ b/src/compiler/lexer/region_handler.rs
@@ -10,7 +10,7 @@ pub enum Reaction {
 }
 
 pub struct RegionHandler {
-    pub region_stack: Vec<Region>,
+    region_stack: Vec<Region>,
     region_map: RegionMap,
     escape: char
 }

--- a/src/compiler/logger/mod.rs
+++ b/src/compiler/logger/mod.rs
@@ -1,4 +1,3 @@
 pub mod logger;
 mod displayer;
 pub use logger::*;
-use displayer::*;

--- a/src/rules/region.rs
+++ b/src/rules/region.rs
@@ -36,7 +36,8 @@ pub struct Region {
     pub tokenize: bool,
     pub allow_left_open: bool,
     pub global: bool,
-    pub references: Option<String>
+    pub references: Option<String>,
+    pub unspillable: bool
 }
 
 impl Region {
@@ -53,7 +54,11 @@ impl Region {
             // This field can allow to leave region 
             // unclosed after parsing has finished
             allow_left_open: false,
+            // Determines if this region is the global context
             global: false,
+            // Determines if region cannot
+            // go past the new line character
+            unspillable: false,
             // Region can be a reference to some other region
             references: match references {
                 Some(value) => Some(String::from(value.as_ref())),
@@ -110,17 +115,20 @@ mod test {
                             interp: vec![],
                             tokenize: true,
                             allow_left_open: false,
+                            unspillable: false,
                             global: false,
                             references: Some(format!("global"))
                         }],
                     tokenize: false,
                     allow_left_open: false,
+                    unspillable: false,
                     global: false,
                     references: None
                 }],
             tokenize: true,
             allow_left_open: true,
             global: true,
+            unspillable: false,
             references: None
         };
         let result = reg!([
@@ -150,6 +158,7 @@ mod test {
             tokenize: true,
             allow_left_open: false,
             global: false,
+            unspillable: false,
             references: Some(
                 "global".to_string(),
             ),
@@ -175,6 +184,7 @@ mod test {
                                 tokenize: true,
                                 allow_left_open: false,
                                 global: false,
+                                unspillable: false,
                                 references: Some(
                                     "global".to_string(),
                                 ),
@@ -183,12 +193,14 @@ mod test {
                         tokenize: false,
                         allow_left_open: false,
                         global: false,
+                        unspillable: false,
                         references: None,
                     },
                 ],
                 tokenize: true,
                 allow_left_open: true,
                 global: true,
+                unspillable: false,
                 references: None,
         });
         expected.insert("string".to_string(), Region {
@@ -206,6 +218,7 @@ mod test {
                     tokenize: true,
                     allow_left_open: false,
                     global: false,
+                    unspillable: false,
                     references: Some(
                         "global".to_string(),
                     ),
@@ -214,6 +227,7 @@ mod test {
             tokenize: false,
             allow_left_open: false,
             global: false,
+            unspillable: false,
             references: None,
         });
         let region = reg!([


### PR DESCRIPTION
Let's remember that languages like Python or Yaml use indentations instead of bracketing in order to parse code. This pull request introduces new way in which we can express our code.

### SeparatorMode
- Manual
- Automatic

Where we can choose if user is obligated to insert separator (usually ';') after each sentence or do we want to support automatic separator insertion.

### ScopingMode
- Block
- Indent

We can choose if our language uses indentations for determining scopes or blocks in form of two enclosing symbols.
