### PR TITLE
H36 Fix: Change the name of the package

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -43,7 +43,7 @@ pub enum ScopingMode {
 /// 
 /// # Example
 /// ```
-/// # use heraclitus::prelude::*;
+/// # use heraclitus_compiler::prelude::*;
 /// # struct GlobalContext {}
 /// # impl SyntaxModule<DefaultMetadata> for GlobalContext {
 /// #   fn new() -> Self { GlobalContext {} }

--- a/src/compiler/logger/logger.rs
+++ b/src/compiler/logger/logger.rs
@@ -25,7 +25,7 @@ pub enum LogType {
 /// Log the message you want to show to the user
 /// # Example
 /// ```should_panic
-/// # use heraclitus::prelude::*;
+/// # use heraclitus_compiler::prelude::*;
 /// # let path = format!("path/to/file");
 /// # let position = (0, 0);
 /// # let guess = "type";

--- a/src/compiler/parser/pattern.rs
+++ b/src/compiler/parser/pattern.rs
@@ -7,7 +7,7 @@ use super::{ Metadata, SyntaxModule };
 /// Otherwise detailed information is returned about where this happened.
 /// # Example
 /// ```
-/// # use heraclitus::prelude::*;
+/// # use heraclitus_compiler::prelude::*;
 /// # fn compile() -> Result<(), ErrorDetails> {
 /// # let meta = &mut DefaultMetadata::new(vec![], None);
 /// token(meta, "let")?;
@@ -30,7 +30,7 @@ pub fn token<T: AsRef<str>>(meta: &mut impl Metadata, text: T) -> Result<String,
 /// Otherwise detailed information is returned about where this happened.
 /// # Example
 /// ```
-/// # use heraclitus::prelude::*;
+/// # use heraclitus_compiler::prelude::*;
 /// # fn compile() -> Result<(), ErrorDetails> {
 /// # let meta = &mut DefaultMetadata::new(vec![], None);
 /// let the_word = token_by(meta, |word| word.starts_with('@'))?;
@@ -53,7 +53,7 @@ pub fn token_by(meta: &mut impl Metadata, cb: impl Fn(&String) -> bool) -> Resul
 /// Otherwise detailed information is returned about where this happened.
 /// # Example
 /// ```
-/// # use heraclitus::prelude::*;
+/// # use heraclitus_compiler::prelude::*;
 /// # struct IfStatement {}
 /// # impl SyntaxModule<DefaultMetadata> for IfStatement {
 /// #   fn new() -> Self { IfStatement {} }
@@ -80,7 +80,7 @@ pub fn syntax<M: Metadata>(meta: &mut M, module: &mut impl SyntaxModule<M>) -> R
 /// Otherwise detailed information is returned about where this happened.
 /// # Example
 /// ```
-/// # use heraclitus::prelude::*;
+/// # use heraclitus_compiler::prelude::*;
 /// # fn compile() -> Result<(), ErrorDetails> {
 /// # let meta = &mut DefaultMetadata::new(vec![], None);
 /// let spaces: usize = indent(meta)?;
@@ -102,7 +102,7 @@ pub fn indent(meta: &mut impl Metadata) -> Result<usize, ErrorDetails> {
 /// Otherwise detailed information is returned about where this happened.
 /// # Example
 /// ```
-/// # use heraclitus::prelude::*;
+/// # use heraclitus_compiler::prelude::*;
 /// # fn compile() -> Result<(), ErrorDetails> {
 /// # let meta = &mut DefaultMetadata::new(vec![], None);
 /// let cmp: std::cmp::Ordering = indent_with(meta, 6)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! Ready to get started?
 //! # Example
 //! ```
-//! use heraclitus::prelude::*;
+//! use heraclitus_compiler::prelude::*;
 //! # let rules = Rules::new(vec![], reg![]);
 //! Compiler::new("HerbScript", rules);
 //! ```
@@ -28,7 +28,7 @@
 //! The `Compiler` requires lexer rules in order to exist.
 //! 
 //! ```
-//! # use heraclitus::prelude::*;
+//! # use heraclitus_compiler::prelude::*;
 //! # fn compiler() -> Result<(), LexerError> {
 //! # let rules = Rules::new(vec![], reg![]);
 //! let cc = Compiler::new("HerbScript", rules);
@@ -46,7 +46,7 @@ pub mod prelude {
     //! This package loads all the most necessary modules into the global scope.
     //! # Example
     //! ```
-    //! use heraclitus::prelude::*;
+    //! use heraclitus_compiler::prelude::*;
     //! ```
     pub use crate::*;
     pub use crate::rules::*;

--- a/src/rules/region.rs
+++ b/src/rules/region.rs
@@ -17,7 +17,7 @@ pub type RegionMap = HashMap<String,Region>;
 /// You shall use this region only as a base for your region structure.
 /// This region's id is called "global" and should remain unique.
 /// ```
-/// # use heraclitus::prelude::*;
+/// # use heraclitus_compiler::prelude::*;
 /// reg![
 ///     // insert other regions here
 /// ];
@@ -31,7 +31,7 @@ pub type RegionMap = HashMap<String,Region>;
 ///  - `singleline`
 /// 
 /// ```
-/// # use heraclitus::prelude::*;
+/// # use heraclitus_compiler::prelude::*;
 /// reg!(str as "string literal" => {
 ///     begin: "'",
 ///     end: "'",
@@ -42,7 +42,7 @@ pub type RegionMap = HashMap<String,Region>;
 /// ## 3. Region with Interpolations
 /// This is a region that can have multiple interpolations of other regions
 /// ```
-/// # use heraclitus::prelude::*;
+/// # use heraclitus_compiler::prelude::*;
 /// reg!(string as "string literal" => {
 ///     begin: "'",
 ///     end: "'"
@@ -55,7 +55,7 @@ pub type RegionMap = HashMap<String,Region>;
 /// This is a region that as interpolation references other region.
 /// 
 /// ```
-/// # use heraclitus::prelude::*;
+/// # use heraclitus_compiler::prelude::*;
 /// reg!(string_interp as "String Interpolation" => {
 ///     begin: "${",
 ///     end: "}",
@@ -98,7 +98,7 @@ macro_rules! reg {
 /// 
 /// # Example
 /// ```
-/// # use heraclitus::prelude::*;
+/// # use heraclitus_compiler::prelude::*;
 /// reg!(str as "string literal" => {
 ///     begin: "'",
 ///     end: "'"

--- a/src/rules/rules.rs
+++ b/src/rules/rules.rs
@@ -12,7 +12,7 @@ use super::region::Region;
 /// 
 /// # Example
 /// ```
-/// # use heraclitus::prelude::*;
+/// # use heraclitus_compiler::prelude::*;
 /// let symbols = vec!['+', '-', '*', '/', '(', ')', '&', '|', '!'];
 /// let region = reg![
 ///     reg!(str as "string literal" => {

--- a/tests/arith.rs
+++ b/tests/arith.rs
@@ -1,4 +1,4 @@
-use heraclitus::prelude::*;
+use heraclitus_compiler::prelude::*;
 mod arith_modules;
 
 #[test]

--- a/tests/arith_modules/add.rs
+++ b/tests/arith_modules/add.rs
@@ -1,4 +1,4 @@
-use heraclitus::prelude::*;
+use heraclitus_compiler::prelude::*;
 use super::*;
 
 #[derive(Debug)]

--- a/tests/arith_modules/expr.rs
+++ b/tests/arith_modules/expr.rs
@@ -1,4 +1,4 @@
-use heraclitus::prelude::*;
+use heraclitus_compiler::prelude::*;
 use super::*;
 
 #[derive(Clone, Debug)]

--- a/tests/arith_modules/number.rs
+++ b/tests/arith_modules/number.rs
@@ -1,4 +1,4 @@
-use heraclitus::prelude::*;
+use heraclitus_compiler::prelude::*;
 
 #[derive(Debug)]
 pub struct Number {

--- a/tests/cobra.rs
+++ b/tests/cobra.rs
@@ -1,4 +1,4 @@
-use heraclitus::prelude::*;
+use heraclitus_compiler::prelude::*;
 mod cobra_modules;
 
 #[test]

--- a/tests/cobra_modules/block.rs
+++ b/tests/cobra_modules/block.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use heraclitus::prelude::*;
+use heraclitus_compiler::prelude::*;
 use super::*;
 
 #[derive(Debug)]

--- a/tests/cobra_modules/expr.rs
+++ b/tests/cobra_modules/expr.rs
@@ -1,4 +1,4 @@
-use heraclitus::prelude::*;
+use heraclitus_compiler::prelude::*;
 use super::text::*;
 
 #[derive(Debug)]

--- a/tests/cobra_modules/if_statement.rs
+++ b/tests/cobra_modules/if_statement.rs
@@ -1,4 +1,4 @@
-use heraclitus::prelude::*;
+use heraclitus_compiler::prelude::*;
 use super::{Expr, Block};
 
 #[derive(Debug)]

--- a/tests/cobra_modules/text.rs
+++ b/tests/cobra_modules/text.rs
@@ -1,4 +1,4 @@
-use heraclitus::prelude::*;
+use heraclitus_compiler::prelude::*;
 
 #[derive(Debug)]
 pub struct Text {


### PR DESCRIPTION
Name `heraclitus` is occupied. We should rename it to `heraclitus_compiler` as this option is vacant.