### PR TITLE
H41 Feature: Rule entry that merges certain symbols into compounds

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -50,7 +50,7 @@ pub enum ScopingMode {
 /// #   fn parse(&mut self, meta: &mut DefaultMetadata) -> SyntaxResult { Ok(()) }
 /// # }
 /// # fn compiler() -> Result<(), ErrorDetails> {
-/// # let rules = Rules::new(vec![], reg![]);
+/// # let rules = Rules::new(vec![], vec![], reg![]);
 /// let mut global_ctx = GlobalContext::new();
 /// let cc = Compiler::new("HerbScript", rules);
 /// let meta = cc.compile(&mut global_ctx)?;

--- a/src/compiler/lexer/compound_handler.rs
+++ b/src/compiler/lexer/compound_handler.rs
@@ -1,0 +1,113 @@
+use std::collections::HashMap;
+use crate::rules::Rules;
+use super::reader::Reader;
+
+#[derive(Debug, PartialEq)]
+pub enum CompoundReaction {
+    Begin,
+    Keep,
+    End,
+    Pass
+}
+
+pub struct CompoundHandler {
+    compound_tree: HashMap<char, Vec<char>>,
+    is_triggered: bool
+}
+
+// Handles compounds
+impl CompoundHandler {
+    pub fn new(rules: &Rules) -> Self {
+        CompoundHandler {
+            compound_tree: Self::generate_compunds(rules.compounds.clone()),
+            is_triggered: false
+        }
+    }
+
+    // Generates a tree where the key is the left item of 
+    // the pair and values are all the right items of the pair
+    fn generate_compunds(word_pairs: Vec<(char, char)>) -> HashMap<char, Vec<char>> {
+        let mut compound_tree = HashMap::new();
+        for (left, right) in word_pairs {
+            compound_tree
+                .entry(left)
+                .or_insert(vec![])
+                .push(right);
+        }
+        compound_tree
+    }
+
+    // Determines what shall we do with detected compound
+    pub fn handle_compound(&mut self, letter: char, reader: &Reader) -> CompoundReaction {
+        // Get completing symbol for current symbol
+        if let Some(entries) = self.compound_tree.get(&letter) {
+            // For any of the completing symbols
+            // check if future symbol satisfies at least one
+            for entry in entries.iter() {
+                // Get future string of current letter and the next one
+                if let Some(future) = reader.get_future(2) {
+                    let future_letter = future.chars().nth(1).unwrap();
+                    // Check if next character matches our desired symbol
+                    if future_letter == *entry {
+                        // If we matched before as well then this means
+                        // that this is a chain of compounds
+                        return if self.is_triggered {
+                            CompoundReaction::Keep
+                        }
+                        // If it's the first time, then this means
+                        // that this is a beginning
+                        else {
+                            self.is_triggered = true;
+                            CompoundReaction::Begin
+                        }
+                    }
+                }
+            }
+        }
+        // If we matched before and no match
+        // was found - end the compound
+        if self.is_triggered {
+            self.is_triggered = false;
+            CompoundReaction::End
+        }
+        // If nothing happened and we didn't
+        // match before - carry on with lexing
+        else {
+            CompoundReaction::Pass
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::vec;
+    use crate::reg;
+    use crate::rules::Region;
+    use crate::rules::Rules;
+    use super::{CompoundHandler, CompoundReaction};
+    use super::Reader;
+
+    #[test]
+    fn match_region() {
+        let expected = vec![
+            CompoundReaction::Pass,
+            CompoundReaction::Begin,
+            CompoundReaction::Keep,
+            CompoundReaction::End,
+            CompoundReaction::Begin,
+            CompoundReaction::End,
+        ];
+        let code = format!("!<=><=");
+        let mut reader = Reader::new(&code);
+        let symbols = vec!['<', '=', '>'];
+        let compounds = vec![('<', '='), ('=', '>')];
+        let rules = Rules::new(symbols, compounds, reg![]);
+        let mut ch = CompoundHandler::new(&rules);
+        let mut result = vec![];
+        // Simulate matching compounds
+        while let Some(letter) = reader.next() {
+            result.push(ch.handle_compound(letter, &reader));
+        }
+        assert_eq!(expected, result);
+    }
+}

--- a/src/compiler/lexer/mod.rs
+++ b/src/compiler/lexer/mod.rs
@@ -2,6 +2,7 @@
 //! 
 //! This module holds all the lexer related modules
 
+mod compound_handler;
 mod region_handler;
 mod reader;
 mod lexer;

--- a/src/compiler/lexer/region_handler.rs
+++ b/src/compiler/lexer/region_handler.rs
@@ -2,7 +2,7 @@ use crate::rules::{Region, Rules, RegionMap};
 use super::reader::Reader;
 
 #[derive(PartialEq)]
-pub enum Reaction {
+pub enum RegionReaction {
     Begin,
     End,
     Pass
@@ -40,7 +40,7 @@ impl RegionHandler {
     }
 
     // Check where we are in code and open / close some region if matched
-    pub fn handle_region(&mut self, reader: &Reader) -> Reaction {
+    pub fn handle_region(&mut self, reader: &Reader) -> RegionReaction {
         // If we are not in the global scope
         if let Some(region) = self.get_region() {
             for interp_region in region.interp.iter() {
@@ -64,7 +64,7 @@ impl RegionHandler {
                             }
                         }
                         self.region_stack.push(begin_region);
-                        return Reaction::Begin
+                        return RegionReaction::Begin
                     }
                 }
             }
@@ -72,11 +72,11 @@ impl RegionHandler {
             if let Some(end_region) = self.match_region_by_end(reader) {
                 if end_region.name == region.name {
                     self.region_stack.pop();
-                    return Reaction::End
+                    return RegionReaction::End
                 }
             }
         }
-        Reaction::Pass
+        RegionReaction::Pass
     }
 
     // Matches region by some getter callback
@@ -123,7 +123,7 @@ impl RegionHandler {
 mod test {
     use crate::reg;
     use crate::rules::Region;
-    use super::{ RegionHandler, Reaction };
+    use super::{ RegionHandler, RegionReaction };
     use super::Reader;
 
     #[test]
@@ -195,7 +195,7 @@ mod test {
         // Simulate matching regions
         while let Some(_) = reader.next() {
             let region_mutated = rh.handle_region(&reader);
-            if let Reaction::Begin | Reaction::End = region_mutated {
+            if let RegionReaction::Begin | RegionReaction::End = region_mutated {
                 result.push(reader.get_index());
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! # Example
 //! ```
 //! use heraclitus_compiler::prelude::*;
-//! # let rules = Rules::new(vec![], reg![]);
+//! # let rules = Rules::new(vec![], vec![], reg![]);
 //! Compiler::new("HerbScript", rules);
 //! ```
 //! It is recommended to use included prelude to import just the things we will actually need.
@@ -30,7 +30,7 @@
 //! ```
 //! # use heraclitus_compiler::prelude::*;
 //! # fn compiler() -> Result<(), LexerError> {
-//! # let rules = Rules::new(vec![], reg![]);
+//! # let rules = Rules::new(vec![], vec![], reg![]);
 //! let cc = Compiler::new("HerbScript", rules);
 //! let tokens = cc.tokenize()?;
 //! # Ok(())

--- a/src/rules/rules.rs
+++ b/src/rules/rules.rs
@@ -14,13 +14,14 @@ use super::region::Region;
 /// ```
 /// # use heraclitus_compiler::prelude::*;
 /// let symbols = vec!['+', '-', '*', '/', '(', ')', '&', '|', '!'];
+/// let compounds = vec![('&', '&'), ('|', '|')];
 /// let region = reg![
 ///     reg!(str as "string literal" => {
 ///         begin: "'",
 ///         end: "'"
 ///     })
 /// ];
-/// Rules::new(symbols, region);
+/// Rules::new(symbols, compounds, region);
 /// ```
 
 #[derive(Debug, Clone, PartialEq)]
@@ -34,13 +35,16 @@ pub struct Rules {
     pub region_tree: Region,
     /// Escape symbol
     pub escape_symbol: char,
+    /// Vector of pairs of symbols that should be merged together
+    pub compounds: Vec<(char, char)>
 }
 
 impl Rules {
     /// Creates new rules that can be supplied to the compiler
-    pub fn new(symbols: Vec<char>, region_tree: Region) -> Rules {
+    pub fn new(symbols: Vec<char>, compounds: Vec<(char, char)>, region_tree: Region) -> Rules {
         Rules {
             symbols,
+            compounds,
             region_tree,
             escape_symbol: '\\'
         }

--- a/tests/arith.rs
+++ b/tests/arith.rs
@@ -10,7 +10,7 @@ fn arith() {
             end: "'"
         })
     ];
-    let rules = Rules::new(symbols, region);
+    let rules = Rules::new(symbols, vec![], region);
     let mut compiler = Compiler::new("Arith", rules);
     compiler.load("12.24 +.123 + 12 + 321");
     let mut expr = arith_modules::Expr::new();

--- a/tests/cobra.rs
+++ b/tests/cobra.rs
@@ -10,7 +10,7 @@ fn cobra() {
             end: "'"
         })
     ];
-    let rules = Rules::new(symbols, region);
+    let rules = Rules::new(symbols, vec![], region);
     let mut compiler = Compiler::new("Arith", rules);
     compiler.use_indents();
     compiler.load(vec![


### PR DESCRIPTION
This utility would be especially helpful for programmer convenience when treating for instance `['<', '=']` tokens as a single `'<='` token