### PR TITLE
H42 Feature: Heraclit version 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "heraclitus-compiler"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "capitalize",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heraclitus-compiler"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Compiler frontend for developing great programming languages"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -42,3 +42,14 @@ The `Compiler` requires lexer rules in order to exist.
 let cc = Compiler::new("HerbScript", rules);
 let tokens = cc.tokenize()?;
 ```
+
+# Change log (0.2.0) 🚀
+
+## Feature:
+- Added compounds
+- Logger can now display messages not related to code
+- New method for retrieving current token
+- New debug functionality
+
+## Fix:
+- Changed string reference of all function parameters to `impl AsRef<str>`


### PR DESCRIPTION
# Change log

## Feature:
- Added compounds
- Logger can now display messages not related to code
- New method for retrieving current token
- New debug functionality

## Fix:
- Changed string reference of all function parameters to `impl AsRef<str>`
