### PR TITLE
H46 Feature: Add Inlines in Lexer

### DIFF
--- a/src/compiler/lexer/lexer.rs
+++ b/src/compiler/lexer/lexer.rs
@@ -51,6 +51,7 @@ impl<'a> Lexer<'a> {
     }
 
     /// Add indentation to the lexem
+    #[inline]
     fn add_indent(&mut self, word: String) -> String {
         if word.len() > 0 {
             // Getting position by word here would attempt to
@@ -66,6 +67,7 @@ impl<'a> Lexer<'a> {
     }
 
     /// Add word that has been completed in previous iteration to the lexem
+    #[inline]
     fn add_word(&mut self, word: String) -> String {
         if word.len() > 0 {
             let (row, col) = self.reader.get_word_position(&word);
@@ -79,6 +81,7 @@ impl<'a> Lexer<'a> {
     }
 
     /// Add word that has been completed in current iteration to the lexem
+    #[inline]
     fn add_word_inclusively(&mut self, word: String) -> String {
         if word.len() > 0 {
             let (row, col) = self.reader.get_word_position(&word);
@@ -92,6 +95,7 @@ impl<'a> Lexer<'a> {
     }
 
     /// Checks whether this is a nontokenizable region
+    #[inline]
     fn is_non_token_region(&self, reaction: RegionReaction) -> bool {
         if let Some(region) = self.region.get_region() {
             !region.tokenize && reaction == RegionReaction::Pass
@@ -101,6 +105,7 @@ impl<'a> Lexer<'a> {
 
     /// Pattern code for adding a symbol
     /// **[*]**
+    #[inline]
     fn pattern_add_symbol(&mut self, mut word: String, letter: char) -> String {
         word = self.add_word(word);
         word.push(letter);
@@ -109,6 +114,7 @@ impl<'a> Lexer<'a> {
 
     /// Pattern code for beginning a new region
     /// **[**
+    #[inline]
     fn pattern_begin(&mut self, mut word: String, letter: char) -> String {
         word = self.add_word(word);
         word.push(letter);
@@ -117,6 +123,7 @@ impl<'a> Lexer<'a> {
 
     /// Pattern code for ending current region
     /// **]**
+    #[inline]
     fn pattern_end(&mut self, mut word: String, letter: char) -> String {
         word.push(letter);
         self.add_word_inclusively(word)

--- a/src/compiler/lexer/reader.rs
+++ b/src/compiler/lexer/reader.rs
@@ -20,6 +20,7 @@ impl<'a> Reader<'a> {
         }
     }
 
+    #[inline]
     pub fn next_letter(&mut self) -> Option<char> {
         if self.row > 0 {
             self.index += 1;
@@ -40,22 +41,26 @@ impl<'a> Reader<'a> {
     }
 
     /// Return current index of the string
+    #[inline]
     pub fn get_index(&self) -> usize {
         self.index
     }
 
     /// Return current position in code
+    #[inline]
     pub fn get_position(&self) -> (usize, usize) {
         (self.row, self.col)
     }
 
     /// Gets position of token that has been read
+    #[inline]
     pub fn get_word_position(&self, word: &String) -> (usize, usize) {
         (self.row, self.col - word.len())
     }
 
     /// Get last n characters that were processed in correct order
     /// This function includes currently processed character
+    #[inline]
     pub fn get_history(&self, n: usize) -> Option<&str> {
         let offset = self.index + 1;
         // Handle arithmetic overflow
@@ -65,6 +70,7 @@ impl<'a> Reader<'a> {
     }
 
     /// Similar to `get_history` but returns a mutable String that can be owned
+    #[inline]
     pub fn get_history_string(&self, n: usize) -> Option<String> {
         match self.get_history(n) {
             Some(value) => Some(String::from(value)),
@@ -73,6 +79,7 @@ impl<'a> Reader<'a> {
     }
 
     /// Show next character that is going to be consumed
+    #[inline]
     pub fn peek(&self) -> Option<char> {
         // Amount required to peek one item in the future
         let one_forward = 2;
@@ -84,6 +91,7 @@ impl<'a> Reader<'a> {
 
     /// Get next n characters that will be processed in correct order
     /// This function includes currently processed character
+    #[inline]
     pub fn get_future(&self, n: usize) -> Option<&str> {
         let begin = self.index;
         // Handle arithmetic overflow
@@ -92,6 +100,7 @@ impl<'a> Reader<'a> {
     }
 
     /// Similar to `get_future` but returns a mutable String that can be owned
+    #[inline]
     pub fn get_future_string(&self, n: usize) -> Option<String> {
         match self.get_future(n) {
             Some(value) => Some(String::from(value)),

--- a/src/compiler/lexer/region_handler.rs
+++ b/src/compiler/lexer/region_handler.rs
@@ -23,12 +23,14 @@ impl RegionHandler {
         }
     }
 
+    #[inline]
     pub fn get_region(&self) -> Option<&Region> {
         self.region_stack.last()
     }
 
     // Error if after code lexing 
     // some region was left unclosed
+    #[inline]
     pub fn is_region_closed(&self, reader: &Reader) -> Result<(),((usize, usize), Region)> {
         if let Some(region) = self.region_stack.last() {
             if !region.allow_left_open {
@@ -84,6 +86,7 @@ impl RegionHandler {
     }
 
     // Matches region by some getter callback
+    #[inline]
     fn match_region_by(&self, reader: &Reader, cb: impl Fn(&Region) -> &String, candidates: &Vec<Region>) -> Option<Region> {
         // Closure that checks if for each given Region is there any that matches current history state
         let predicate = |candidate: &Region| match reader.get_history(cb(candidate).len()) {
@@ -100,11 +103,13 @@ impl RegionHandler {
         self.get_region_by(predicate, candidates)
     }
 
+    #[inline]
     fn match_region_by_begin(&self, reader: &Reader) -> Option<Region> {
         let region = self.get_region().unwrap();
         self.match_region_by(reader, |candidate: &Region| &candidate.begin, &region.interp)
     }
 
+    #[inline]
     fn match_region_by_end(&self, reader: &Reader) -> Option<Region> {
         let region = self.get_region().unwrap();
         if !region.global {
@@ -113,6 +118,7 @@ impl RegionHandler {
     }
 
     // Target region is a region on which we want to search the interpolations
+    #[inline]
     fn get_region_by(&self, cb: impl Fn(&Region) -> bool, candidates: &Vec<Region>) -> Option<Region> {
         for region in candidates.iter() {
             if cb(region) {


### PR DESCRIPTION
Add `#[inline]` attribute to the really intensively used parts of code of the lexer.