### PR TITLE
H49 Feature: Publish Major Version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "heraclitus-compiler"
-version = "0.2.1"
+version = "1.2.2"
 dependencies = [
  "capitalize",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heraclitus-compiler"
-version = "0.2.1"
+version = "1.2.2"
 edition = "2021"
 description = "Compiler frontend for developing great programming languages"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -45,13 +45,16 @@ let tokens = cc.tokenize()?;
 
 # Change log 🚀
 
-## Version 0.2.1
+## Version 1.2.2
+### Fix:
+- Major bug with a tokenised interpolation being parsed in a wrong way.
+- Intensively used code is now inlined at compile time
 
+## Version 0.2.1
 ### Feature:
 - `ErrorDetails::from_token_option(...)` can now be used to create errors at location of given token
 
 ## Version 0.2.0
-
 ### Feature:
 - Added compounds
 - Logger can now display messages not related to code


### PR DESCRIPTION
Change log:
Fixed:
- Major bug with a tokenised interpolation being parsed in a wrong way.
- Intensively used code is now inlined at compile time