### PR TITLE
H50 Feature: Set offset for metadata index

### DIFF
--- a/src/compiling/lexing/lexer.rs
+++ b/src/compiling/lexing/lexer.rs
@@ -158,7 +158,6 @@ impl<'a> Lexer<'a> {
                         self.position = self.reader.get_position();
                     }
                 }
-                
             }
 
             // Reaction stores the reaction of the region handler

--- a/src/compiling/parser/metadata.rs
+++ b/src/compiling/parser/metadata.rs
@@ -74,4 +74,9 @@ pub trait Metadata {
         let index = self.get_index();
         self.get_token_at(index)
     }
+    /// Change current index by given offset
+    fn offset_index(&mut self, offset: usize) {
+        let index = self.get_index();
+        self.set_index(index + offset);
+    }
 }


### PR DESCRIPTION
Currently if we want to move back, we have to write `meta.set_index(meta.get_index() - 1)`.
It would be good to create a wrapper for this expression that can be written like so `meta.offset_index(-1)`.