### PR TITLE
Remove the necessity of providing code in a string format if path to a file is available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "heraclitus-compiler"
-version = "1.5.5"
+version = "1.5.6"
 dependencies = [
  "capitalize",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heraclitus-compiler"
-version = "1.5.5"
+version = "1.5.6"
 edition = "2021"
 description = "Compiler frontend for developing great programming languages"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ let tokens = cc.tokenize()?;
 
 # Change log 🚀
 
+## Version 1.5.6
+### Fix:
+- Compiler now does not rely strongly on provided source code. It can now open files from path if provided. This can improve drastically performance of the compiler when working with imports.
+
 ## Version 1.5.5
 ### Feature:
 - Show elapsed time in parser debug mode

--- a/src/compiling/failing/logger.rs
+++ b/src/compiling/failing/logger.rs
@@ -166,25 +166,36 @@ impl Logger {
     }
 
     /// Render snippet of the code if the message is contextual to it
-    pub fn snippet<T: AsRef<str>>(self, code: Option<T>) {
-        let (row, _, _) = self.get_row_col_len();
+    pub fn snippet<T: AsRef<str>>(self, code: Option<T>) -> Self {
+        if let Some(pos) = self.trace.first() {
+            if let Ok(code) = std::fs::read_to_string(pos.get_path()) {
+                self.snippet_from_code(code);
+                return self;
+            }
+        }
         if let Some(code) = code {
-            let mut overflow = 0;
-            let index = row - 1;
-            let code: String = String::from(code.as_ref());
-            let code = code.split('\n')
-                .map(|item| item.to_string())
-                .collect::<Vec<String>>();
-            eprintln!();
-            // Show additional code above the snippet
-            if index > 0 {
-                eprintln!("{}", self.get_snippet_row(&code, index, -1, &mut overflow));
-            }
-            eprintln!("{}", self.get_snippet_row(&code, index, 0, &mut overflow));
-            // Show additional code below the snippet
-            if index < code.len() - 1 {
-                eprintln!("{}", self.get_snippet_row(&code, index, 1, &mut overflow));
-            }
+            self.snippet_from_code(code.as_ref().to_string());
+        }
+        self
+    }
+
+    /// Render snippet of the code based on the code data
+    fn snippet_from_code(&self, code: String) {
+        let (row, _, _) = self.get_row_col_len();
+        let mut overflow = 0;
+        let index = row - 1;
+        let code = code.split('\n')
+            .map(|item| item.to_string())
+            .collect::<Vec<String>>();
+        eprintln!();
+        // Show additional code above the snippet
+        if index > 0 {
+            eprintln!("{}", self.get_snippet_row(&code, index, -1, &mut overflow));
+        }
+        eprintln!("{}", self.get_snippet_row(&code, index, 0, &mut overflow));
+        // Show additional code below the snippet
+        if index < code.len() - 1 {
+            eprintln!("{}", self.get_snippet_row(&code, index, 1, &mut overflow));
         }
     }
 }

--- a/src/compiling/failing/message.rs
+++ b/src/compiling/failing/message.rs
@@ -154,7 +154,7 @@ impl Message {
                 .text(self.message.clone())
                 .path()
                 .padded_text(self.comment.clone())
-                .snippet(self.code.clone())
+                .snippet(self.code.clone());
         }
         // If this error is a message error
         else {


### PR DESCRIPTION
Compiler now does not rely strongly on provided source code. It can now open files from path if provided. This can improve drastically performance of the compiler when working with imports.