### PR TITLE
H65 Region beginning should capture code in the future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "heraclitus-compiler"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "capitalize",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heraclitus-compiler"
-version = "1.5.6"
+version = "1.5.7"
 edition = "2021"
 description = "Compiler frontend for developing great programming languages"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ let tokens = cc.tokenize()?;
 
 # Change log 🚀
 
+## Version 1.5.7
+### Fix:
+- Major fix that caused the lexer to lead to an undefined behavior with defining a region that has a beginning rule longer than one character.
+
 ## Version 1.5.6
 ### Fix:
 - Compiler now does not rely strongly on provided source code. It can now open files from path if provided. This can improve drastically performance of the compiler when working with imports.

--- a/src/compiling/lexing/reader.rs
+++ b/src/compiling/lexing/reader.rs
@@ -1,6 +1,11 @@
 #![allow(dead_code)]
 const BEGINNING: (usize, usize) = (0, 1);
 
+pub enum ReadMode {
+    History,
+    Future
+}
+
 pub struct Reader<'a> {
     pub code: &'a String,
     pub row: usize,
@@ -83,6 +88,15 @@ impl<'a> Reader<'a> {
         match self.get_future(one_forward) {
             Some(value) => value.chars().nth(one_forward - 1),
             None => None
+        }
+    }
+
+    /// Show next character that is going to be consumed depending on the mode
+    #[inline]
+    pub fn get_history_or_future(&self, n: usize, mode: &ReadMode) -> Option<String> {
+        match mode {
+            ReadMode::History => self.get_history(n),
+            ReadMode::Future => self.get_future(n)
         }
     }
 

--- a/tests/arith.rs
+++ b/tests/arith.rs
@@ -3,16 +3,20 @@ mod arith_modules;
 
 #[test]
 fn arith() {
-    let symbols = vec!['+'];
+    let symbols = vec!['+', '/'];
     let region = reg![
         reg!(string as "string literal" => {
             begin: "'",
             end: "'"
+        }),
+        reg!(comment as "comment line" => {
+            begin: "//",
+            end: "\n"
         })
     ];
     let rules = Rules::new(symbols, vec![], region);
     let mut compiler = Compiler::new("Arith", rules);
-    compiler.load("12.24 +.123 + 12 + 321");
+    compiler.load("// test\n12.24 +.123 + 12 + 321");
     let mut expr = arith_modules::Expr::new();
     compiler.debug();
     assert!(compiler.compile(&mut expr).is_ok());

--- a/tests/arith_modules/expr.rs
+++ b/tests/arith_modules/expr.rs
@@ -33,6 +33,14 @@ impl Expr {
                 return Err(Failure::Quiet(PositionInfo::from_metadata(meta)))
             }
         }
+        // Skip comments
+        while let Some(token) = meta.get_current_token() {
+            if token.word.starts_with("//") || token.word.starts_with("\n") {
+                meta.increment_index();
+            } else {
+                break
+            }
+        }
         // Match syntax
         match syntax(meta, &mut module) {
             Ok(()) => {


### PR DESCRIPTION
Currently when we are about to parse the region - we end up looking back to the history. That is an unwanted behaviour.