### PR TITLE
H66 Fix: Escaping regions does not work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "heraclitus-compiler"
-version = "1.5.7"
+version = "1.5.8"
 dependencies = [
  "capitalize",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heraclitus-compiler"
-version = "1.5.7"
+version = "1.5.8"
 edition = "2021"
 description = "Compiler frontend for developing great programming languages"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ let tokens = cc.tokenize()?;
 
 # Change log 🚀
 
+## Version 1.5.8
+### Fix:
+- Escaping regions is now properly handled
+
 ## Version 1.5.7
 ### Fix:
 - Major fix that caused the lexer to lead to an undefined behavior with defining a region that has a beginning rule longer than one character.

--- a/src/compiling/lexing/region_handler.rs
+++ b/src/compiling/lexing/region_handler.rs
@@ -92,8 +92,13 @@ impl RegionHandler {
         // Closure that checks if for each given Region is there any that matches current history state
         let predicate = |candidate: &Region| match reader.get_history_or_future(cb(candidate).len(), &read_mode) {
             Some(code_chunk) => {
+                // Check if the region was escaped (the escape symbol will always be in a history)
+                let is_escaped = match read_mode {
+                    ReadMode::History => reader.get_history(cb(candidate).len() + 1),
+                    ReadMode::Future => reader.get_history(2)
+                };
                 // Check if the region was escaped
-                let is_escaped = match reader.get_history_or_future(cb(candidate).len() + 1, &read_mode) {
+                let is_escaped = match is_escaped {
                     Some(code_chunk_with_escape) => code_chunk_with_escape.chars().next().unwrap() == self.escape,
                     None => false
                 };


### PR DESCRIPTION
Fix escaping regions. Assuming `{` is a beginning of a region and `}` is an ending of a region, `\{}` does not take any effect of escaping the expression. The expression parses correctly which is a bad behaviour.