### PR TITLE
Escaping escape character keeps treating it as escape character

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "capitalize"
-version = "0.1.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702cfe2f052c6542d55a9924efef63dd315c168cc4f315a824fb0f47da4e11c8"
+checksum = "6b5271031022835ee8c7582fe67403bd6cb3d962095787af7921027234bab5bf"
 
 [[package]]
 name = "colored"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "heraclitus-compiler"
-version = "1.5.8"
+version = "1.5.9"
 dependencies = [
  "capitalize",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ keywords = ["heraclitus", "compiler", "parser"]
 [dependencies]
 colored = "2.0.0"
 pad = "0.1.6"
-capitalize = "0.1.0"
+capitalize = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heraclitus-compiler"
-version = "1.5.8"
+version = "1.5.9"
 edition = "2021"
 description = "Compiler frontend for developing great programming languages"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ let tokens = cc.tokenize()?;
 
 # Change log 🚀
 
+## Version 1.5.9
+### Fix:
+- Escaping escape key now treats it as a character
+
 ## Version 1.5.8
 ### Fix:
 - Escaping regions is now properly handled

--- a/tests/cobra.rs
+++ b/tests/cobra.rs
@@ -15,7 +15,7 @@ fn cobra() {
     let mut compiler = Compiler::new("Cobra", rules);
     compiler.use_indents();
     compiler.load(vec![
-        "if 'condition':",
+        "if 'condition\\\\':",
         "  'do + this'",
         "  'do ++ that'"
     ].join("\n"));


### PR DESCRIPTION
`"\\"` spits out error that region is unclosed - because `\` is not escaped by it's previous instance